### PR TITLE
chore: add first-party forms and security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,18 @@
   from = "/*"
   to = "/404.html"
   status = 404
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(), payment=(self)"
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://checkout.stripe.com; img-src 'self' data: blob: https:; font-src 'self' data: https:; style-src 'self' 'unsafe-inline' https:; script-src 'self' 'unsafe-inline' https://js.stripe.com https://www.googletagmanager.com https://connect.facebook.net; connect-src 'self' https://api.stripe.com https://www.google-analytics.com https://www.facebook.com; frame-src https://js.stripe.com https://checkout.stripe.com https://www.youtube.com https://www.youtube-nocookie.com https://hhsdemo2.netlify.app; upgrade-insecure-requests; block-all-mixed-content"
+
+[[headers]]
+  for = "/_next/static/*"
+  [headers.values]
+    Cache-Control = "max-age=31536000, immutable"

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 
 import NavIsland from '@/components/NavIsland';
 import Section from '@/components/Section';
-// Removed FormPlaceholder in favor of external embedded form
+// First-party HHS contact form
 import Glow from '@/components/Glow';
 import ContactForm from '@/components/ContactForm';
 

--- a/src/app/packages/[slug]/PackageClient.tsx
+++ b/src/app/packages/[slug]/PackageClient.tsx
@@ -29,6 +29,7 @@ interface PackageData {
 
 export default function PackageClient({ packageData }: { packageData: PackageData }) {
   const { name, price, description, features, videoId, popular, buttonText, faqs } = packageData;
+  const packageSlug = name.toLowerCase().split(' ')[0];
 
   return (
     <main className="relative min-h-screen bg-black">
@@ -154,17 +155,7 @@ export default function PackageClient({ packageData }: { packageData: PackageDat
               transition={{ duration: 0.6, delay: 0.2 }}
             >
               <a
-                href={
-                  name.startsWith('Starter')
-                    ? 'https://api.leadconnectorhq.com/widget/form/gFcy5EMvzPhWpCRF8sPs'
-                    : name.startsWith('Standard')
-                      ? 'https://api.leadconnectorhq.com/widget/form/yQpBSS0mCcTbwSZGvfvm'
-                      : name.startsWith('Professional')
-                        ? 'https://api.leadconnectorhq.com/widget/form/NzcNkp9t4hwymDypmfed'
-                        : 'https://api.leadconnectorhq.com/widget/bookings/hhs'
-                }
-                target="_blank"
-                rel="noopener noreferrer"
+                href={`/contact?package=${packageSlug}`}
                 className="group inline-flex items-center justify-center px-10 py-4 text-lg font-semibold text-white bg-gradient-to-r from-primary-emerald via-primary-emerald to-primary-blue rounded-full hover:shadow-2xl hover:shadow-primary-emerald/30 transition-all duration-500 transform hover:scale-105 hover:-translate-y-1 relative overflow-hidden border border-primary-emerald/30 hover:border-primary-emerald/60"
               >
                 <span className="absolute inset-0 bg-gradient-to-r from-primary-emerald/10 to-primary-blue/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />


### PR DESCRIPTION
## Summary
- Replace retired GHL/LeadConnector form embeds/references with first-party HHS-controlled forms or contact routes
- Add/update Netlify security headers and CSP for the current site
- Keep temporary Netlify Forms fallback while final backend decision is parked for the 10:30 meeting

## Verification
- npm run build passed locally
- git diff --check passed locally
- Added-lines static security scan found no hardcoded secrets/eval/exec/unsafe HTML patterns
- Source scan found no active retired GHL/LeadConnector/msgsndr references in relevant source/config files
- Independent code review passed after CSP fix

## Notes for review
- Do not merge until human review is complete
- Remaining decisions: final form backend, notification routing, Stripe implementation mode, pricing/upkeep tiers, and solar lead follow-up owner