### PR TITLE
fix: remove flashing grid and crop turtle avatar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,25 +30,9 @@ body {
   position: relative;
 }
 
+/* Removed the full-page grid overlay; floating dot particles remain active. */
 body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-image: 
-    linear-gradient(rgba(52, 211, 153, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(52, 211, 153, 0.03) 1px, transparent 1px);
-  background-size: 60px 60px;
-  pointer-events: none;
-  z-index: 1;
-  animation: grid-move 25s linear infinite;
-}
-
-@keyframes grid-move {
-  0% { transform: translate(0, 0); }
-  100% { transform: translate(60px, 60px); }
+  content: none;
 }
 
 /* Enhanced futuristic button styles */

--- a/src/components/TurtleChatWidget.tsx
+++ b/src/components/TurtleChatWidget.tsx
@@ -53,14 +53,16 @@ function TurtleCharacter({ compact = false }: { compact?: boolean }) {
   return (
     <div className={`relative ${compact ? 'h-12 w-12' : 'h-16 w-16'}`} aria-hidden="true">
       <div className="absolute inset-0 rounded-full bg-primary-emerald/25 blur-xl" />
-      <Image
-        src="/hhs-turtle-chat.jpg"
-        alt=""
-        width={size}
-        height={size}
-        className="relative h-full w-full rounded-full border-2 border-primary-emerald/60 object-cover object-center drop-shadow-[0_0_18px_rgba(52,211,153,0.42)]"
-        priority={false}
-      />
+      <div className="relative h-full w-full overflow-hidden rounded-full border-2 border-primary-emerald/60 bg-black/80 drop-shadow-[0_0_18px_rgba(52,211,153,0.42)]">
+        <Image
+          src="/hhs-turtle-chat.jpg"
+          alt=""
+          width={size}
+          height={size}
+          className="h-full w-full scale-[1.45] object-cover object-[50%_38%]"
+          priority={false}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the full-page animated grid overlay while keeping floating dot particles active
- tighten the turtle chat avatar crop so less photo background is visible

## Test Plan
- npm run build
- local browser DOM check confirmed grid animation removed and particle animations still running